### PR TITLE
Reduce cpu/memory usage on startup

### DIFF
--- a/app/config.sample.json
+++ b/app/config.sample.json
@@ -9,7 +9,7 @@
       "tabReloadIntervalSeconds": 15
     },
     {
-      "url": "chrome-extension://jfkiojppjjbeihfgjackkcmebkmeoich/app/settings.html",
+      "url": "chrome-extension://pjgjpabbgnnoohijnillgbckikfkbjed/app/settings.html",
       "duration": 10,
       "tabReloadIntervalSeconds": 15
     },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Tab Rotate",
   "description": "Loop through a set of tabs - ideal for a Dashboard or Advertisement Display",
-  "version": "0.2.1",
+  "version": "0.2.2",
 
   "browser_action": {
     "default_icon": "app/img/Play-38.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-tab-rotate",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Loop through a set of tabs - ideal for a Dashboard or Advertisement Display",
   "main": "gulpfile.js",
   "dependencies": {


### PR DESCRIPTION
#27 Now default behaviour to only load the first two websites on startup.
Each subsequent website will be preloaded "just in time", before it becomes active.
This should hopefully reduce cpu/memory/bandwidth usage spikes on startup which were causing issues on low power devices like Rasberry Pi