### PR TITLE
fix for only loading first two tabs on startup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Tab Rotate",
   "description": "Loop through a set of tabs - ideal for a Dashboard or Advertisement Display",
-  "version": "0.3.3",
+  "version": "0.3.4",
 
   "browser_action": {
     "default_icon": "src/img/Play-38.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-tab-rotate",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Loop through a set of tabs - ideal for a Dashboard or Advertisement Display",
   "main": "gulpfile.js",
   "dependencies": {


### PR DESCRIPTION
The first implementation of this caused a regression when:
`tabReloadIntervalSeconds: 0`

In this case, the site would never load.
This fix addresses that regression.